### PR TITLE
Do not use default locale when creating the vex url

### DIFF
--- a/app/models/Deployment.java
+++ b/app/models/Deployment.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -318,7 +319,7 @@ public class Deployment extends Model {
             Rectangle2D bounds = getBounds();
 
             // call vex server
-            URL vexUrl = new URL(String.format("%s/?n=%.6f&e=%.6f&s=%.6f&w=%.6f",
+            URL vexUrl = new URL(String.format(Locale.US,"%s/?n=%.6f&e=%.6f&s=%.6f&w=%.6f",
                     Play.application().configuration().getString("application.deployment.osm_vex"),
                     bounds.getMaxY(), bounds.getMaxX(), bounds.getMinY(), bounds.getMinX()));
 


### PR DESCRIPTION
Vex server requires period as the decimal separator so a locale that uses period as decimal separator must be used or the request will fail..
